### PR TITLE
Crude support for Amber AMB8465-M (probably other Amber devices as well)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Supported USB Adapters:
 
 + [iM871A](http://www.wireless-solutions.de/products/gateways/wirelessadapter)
 + [CUL](http://shop.busware.de/product_info.php/products_id/29?osCsid=eab2ce6ef5efc95dbdf61396ca256b6e)
++ [Amber 8465-M](https://www.amber-wireless.de/en/amb8465-m.html)
 
 #### Configuration
 

--- a/wm-bus.js
+++ b/wm-bus.js
@@ -373,8 +373,8 @@ AmberCom.prototype.onData = function (data) {
     if (this.telegramLength <= this.frameBuffer.byteLength) {
         adapter.log.debug('telegram received: ' + this.frameBuffer.toString('hex'));
         this.wmbus.crcRemoved = true;
-        this.wmbus.parse(this.frameBuffer.toString().substr(2, this.telegramLength - 4));
-        this.telegramLength == -1;
+        this.wmbus.parse(this.frameBuffer.toString('hex', 2, this.telegramLength - 2));
+        this.telegramLength = -1;
         this.frameBuffer = false;
     }
 };

--- a/wm-bus.js
+++ b/wm-bus.js
@@ -373,7 +373,7 @@ AmberCom.prototype.onData = function (data) {
     if (this.telegramLength <= this.frameBuffer.byteLength) {
         adapter.log.debug('telegram received: ' + this.frameBuffer.toString('hex'));
         this.wmbus.crcRemoved = true;
-        this.wmbus.parse(this.frameBuffer.toString('hex', 2, this.telegramLength - 2));
+        this.wmbus.parseHex(this.frameBuffer.toString('hex', 2, this.telegramLength - 2));
         this.telegramLength = -1;
         this.frameBuffer = false;
     }


### PR DESCRIPTION
This reads directly from the serial port. Buffering of incoming chunks is not very robust. ~~Checksums are discarded unchecked.~~ Last byte is checked - no idea about the second to last byte...

So far tested only with an external temperature sensor [Pikkerton MBS-120](https://www.pikkerton.de/Produkte/Produkte_nach_Kommunikationsprotokoll/Produkte_Endgeraete/10.htm).

I hope I did not break support for iM871A 😅 